### PR TITLE
Align package name with plugin manifest and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ Follow these steps in order. Ask the user for their PPQ API key when needed.
 
 ### Step 1: Get the user's PPQ API key
 
-Ask the user for their PPQ.AI API key. They can find it at https://ppq.ai/api-docs — it starts with `sk-`.
+First, check if the user already has a PPQ API key configured. Read `~/.openclaw/openclaw.json` and look for an existing key in any of these locations:
+- `plugins.entries.ppq-private-mode.config.apiKey`
+- `plugins.entries.ppq-tinfoil-proxy.config.apiKey`
+- Any provider config with a `baseUrl` pointing to `api.ppq.ai`
+
+If a valid key is found (starts with `sk-`), reuse it — no need to ask the user. Let them know you found their existing key.
+
+If no key is found, ask the user for their PPQ.AI API key. They can find it at https://ppq.ai/api-docs — it starts with `sk-`.
 
 ### Step 2: Install the plugin
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ppq/private-mode-proxy",
+  "name": "ppq-private-mode",
   "version": "0.1.0",
   "type": "module",
   "description": "End-to-end encrypted AI proxy for PPQ.AI private models. Works standalone or as an OpenClaw plugin.",


### PR DESCRIPTION
## Summary
- Renames `package.json` name from `@ppq/private-mode-proxy` to `ppq-private-mode` to match `openclaw.plugin.json` id and `index.ts` export, fixing `openclaw plugins install` warnings caused by the mismatch
- Adds API key auto-detection to README Step 1 so existing PPQ users aren't re-prompted for a key they already have

## Test plan
- [x] All three names now match: `package.json` name, `openclaw.plugin.json` id, `index.ts` export const id
- [x] README setup instructions check for existing key before prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)