### PR TITLE
Add Docker support and fix a few bugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+.git/
+.env
+.env.*
+docker-compose.yml

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Required: your PPQ.AI API key (get from https://ppq.ai/api-docs)
+PPQ_API_KEY=sk-your-key-here
+
+# Optional: enable verbose logging
+DEBUG=false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+docker-compose.yml
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+ENV HOST=0.0.0.0
+ENV PORT=8787
+
+EXPOSE 8787
+
+CMD ["npx", "tsx", "bin/server.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ENV PORT=8787
 
 EXPOSE 8787
 
-CMD ["npx", "tsx", "bin/server.ts"]
+CMD ["node", "--import", "tsx", "bin/server.ts"]

--- a/README.md
+++ b/README.md
@@ -61,9 +61,50 @@ const response = await client.chat.completions.create({
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `PPQ_API_KEY` | Yes | — | Your PPQ.AI API key |
+| `HOST` | No | `127.0.0.1` | Bind address |
 | `PORT` | No | `8787` | Local proxy port |
 | `PPQ_API_BASE` | No | `https://api.ppq.ai` | PPQ API base URL |
 | `DEBUG` | No | `false` | Set to `true` for verbose logging |
+
+# Docker
+
+You can run the proxy in Docker instead of installing Node.js locally. A prebuilt image is published to GitHub Container Registry.
+
+**Run with the published image:**
+
+```bash
+docker run -d --name ppq-proxy \
+  -p 8787:8787 \
+  -e PPQ_API_KEY=sk-your-key \
+  ghcr.io/payperq/ppq-private-mode-proxy:latest
+```
+
+**Or build locally:**
+
+```bash
+docker build -t ppq-proxy .
+docker run -d --name ppq-proxy \
+  -p 8787:8787 \
+  -e PPQ_API_KEY=sk-your-key \
+  ppq-proxy
+```
+
+The proxy will be available at `http://localhost:8787`.
+
+**Test it:**
+
+```bash
+curl http://localhost:8787/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"private/kimi-k2-5","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+**View logs / stop:**
+
+```bash
+docker logs -f ppq-proxy
+docker stop ppq-proxy && docker rm ppq-proxy
+```
 
 ## How This proxy repo works
 

--- a/bin/server.ts
+++ b/bin/server.ts
@@ -7,6 +7,7 @@
  *
  * Environment variables:
  *   PPQ_API_KEY   (required) — Your PPQ.AI API key from https://ppq.ai/api-docs
+ *   HOST          (optional) — Bind address, default 127.0.0.1
  *   PORT          (optional) — Proxy port, default 8787
  *   PPQ_API_BASE  (optional) — API base URL, default https://api.ppq.ai
  *   DEBUG         (optional) — Set to "true" for verbose logging
@@ -21,12 +22,13 @@ if (!apiKey) {
   process.exit(1);
 }
 
+const host = process.env.HOST || "127.0.0.1";
 const port = parseInt(process.env.PORT || "8787", 10);
 const apiBase = process.env.PPQ_API_BASE || "https://api.ppq.ai";
 const debug = process.env.DEBUG === "true";
 
 const proxy = await startProxy(
-  { apiKey, port, apiBase, debug },
+  { apiKey, host, port, apiBase, debug },
   {
     info: (msg) => console.log(msg),
     error: (msg) => console.error(msg),

--- a/index.ts
+++ b/index.ts
@@ -76,7 +76,7 @@ export default function register(api: any) {
         // Health check
         try {
           const resp = await fetch(`http://127.0.0.1:${proxy.port}/health`);
-          const health = await resp.json();
+          await resp.json();
 
           return {
             content: [

--- a/index.ts
+++ b/index.ts
@@ -219,6 +219,7 @@ export default function register(api: any) {
 
       const config: ProxyConfig = {
         apiKey: pluginConfig.apiKey,
+        host: "127.0.0.1",
         port: pluginConfig.port || 8787,
         apiBase: pluginConfig.apiBase || "https://api.ppq.ai",
         debug: pluginConfig.debug || false,

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -45,7 +45,6 @@ export interface Logger {
 
 const DEFAULT_PORT = 8787;
 const DEFAULT_API_BASE = "https://api.ppq.ai";
-const HEALTH_TIMEOUT_MS = 15_000;
 
 /** Maps user-facing model IDs to enclave-internal model IDs */
 const PRIVATE_MODEL_MAP: Record<string, string> = {
@@ -59,41 +58,15 @@ const PRIVATE_MODEL_MAP: Record<string, string> = {
 /** All available private model IDs (user-facing) */
 const PRIVATE_MODELS = Object.keys(PRIVATE_MODEL_MAP);
 
-/** OpenAI-format model list response */
+/** OpenAI-format model list response (derived from PRIVATE_MODEL_MAP) */
 const MODEL_LIST_RESPONSE = {
   object: "list",
-  data: [
-    {
-      id: "private/kimi-k2-5",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-    {
-      id: "private/deepseek-r1-0528",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-    {
-      id: "private/gpt-oss-120b",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-    {
-      id: "private/llama3-3-70b",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-    {
-      id: "private/qwen3-vl-30b",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-  ],
+  data: PRIVATE_MODELS.map((id) => ({
+    id,
+    object: "model",
+    created: 0,
+    owned_by: "ppq-private",
+  })),
 };
 
 // ─── Proxy server ────────────────────────────────────────────────────────────
@@ -128,7 +101,7 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
     logger.info("Attestation completed (verification document unavailable)");
   }
 
-  const encryptedFetch = client.fetch;
+  const encryptedFetch = client.fetch.bind(client);
 
   const server = http.createServer(async (req, res) => {
     // CORS headers
@@ -142,7 +115,7 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
       return;
     }
 
-    const url = new URL(req.url || "/", `http://127.0.0.1:${port}`);
+    const url = new URL(req.url || "/", `http://${host}:${port}`);
 
     // GET /health
     if (url.pathname === "/health" || url.pathname === "/") {

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -22,6 +22,7 @@ import type { SecureClient, VerificationDocument } from "tinfoil";
 
 export interface ProxyConfig {
   apiKey: string;
+  host: string;
   port: number;
   apiBase: string;
   debug: boolean;
@@ -98,6 +99,7 @@ const MODEL_LIST_RESPONSE = {
 // ─── Proxy server ────────────────────────────────────────────────────────────
 
 export async function startProxy(config: ProxyConfig, logger: Logger): Promise<ProxyHandle> {
+  const host = config.host || "127.0.0.1";
   const port = config.port || DEFAULT_PORT;
   const apiBase = config.apiBase || DEFAULT_API_BASE;
 
@@ -284,8 +286,8 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
   // Start listening
   await new Promise<void>((resolve, reject) => {
     server.on("error", reject);
-    server.listen(port, "127.0.0.1", () => {
-      logger.info(`PPQ Private Mode proxy listening on http://127.0.0.1:${port}`);
+    server.listen(port, host, () => {
+      logger.info(`PPQ Private Mode proxy listening on http://${host}:${port}`);
       logger.info(`Endpoints: GET /v1/models, POST /v1/chat/completions`);
       resolve();
     });

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "files": ["index.ts", "lib", "bin", "skills", "openclaw.plugin.json"],
   "dependencies": {
-    "tinfoil": "^1.0.0",
-    "zod": "^4.0.0"
+    "tinfoil": "^1.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.0"


### PR DESCRIPTION
This adds Docker support for running the proxy without needing Node.js installed locally, plus a GitHub Actions workflow that builds and publishes the image to ghcr.io.

Also fixed some bugs I found while reviewing the code:

- `client.fetch` was being assigned to a variable without `.bind(client)`, which would break if tinfoil's fetch method uses `this` internally
- `HEALTH_TIMEOUT_MS` was declared but never used anywhere
- `zod` was in dependencies but nothing imports it
- The model list response was manually duplicated from `PRIVATE_MODEL_MAP` - derived it automatically now so they cant get out of sync
- URL constructor in the request handler was hardcoded to 127.0.0.1 instead of using the configured host

Other changes:
- Added a `host` config option (defaults to 127.0.0.1) so the bind address is configurable. This was needed for Docker since binding to localhost inside a container makes the port unreachable from outside
- Added .dockerignore so .git and .env dont end up in the image
- Dockerfile uses `node --import tsx` instead of `npx tsx` for faster startup

## Testing

Built the image and ran it locally, verified all 3 endpoints work (health, models, chat completions). Got a succesful response from kimi-k2-5 through the encrypted proxy.