### PR TITLE
Migrate from deprecated Kimi K2.5 / DeepSeek R1 to Kimi K2.6 (PayPerQ/PPQdotAI#2126, #2282)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The proxy starts on port 8787 and prints a ready message once attestation succee
 ```bash
 curl http://127.0.0.1:8787/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"private/kimi-k2-5","messages":[{"role":"user","content":"Hello"}]}'
+  -d '{"model":"private/kimi-k2-6","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
 **Or point any OpenAI SDK at it:**
@@ -51,7 +51,7 @@ const client = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-  model: "private/kimi-k2-5",
+  model: "private/kimi-k2-6",
   messages: [{ role: "user", content: "Hello" }],
 });
 ```

--- a/bin/server.ts
+++ b/bin/server.ts
@@ -38,7 +38,7 @@ console.log("");
 console.log("Send a test request:");
 console.log(`  curl http://127.0.0.1:${proxy.port}/v1/chat/completions \\`);
 console.log(`    -H "Content-Type: application/json" \\`);
-console.log(`    -d '{"model":"private/kimi-k2-5","messages":[{"role":"user","content":"Hello"}]}'`);
+console.log(`    -d '{"model":"private/kimi-k2-6","messages":[{"role":"user","content":"Hello"}]}'`);
 console.log("");
 
 // Graceful shutdown

--- a/index.ts
+++ b/index.ts
@@ -98,6 +98,7 @@ export default function register(api: any) {
                   },
                   availableModels: [
                     "private/kimi-k2-5",
+                    "private/kimi-k2-6",
                     "private/deepseek-r1-0528",
                     "private/gpt-oss-120b",
                     "private/llama3-3-70b",
@@ -142,6 +143,15 @@ export default function register(api: any) {
           name: "Kimi K2.5 (Private)",
           reasoning: false,
           input: ["text"],
+          cost: { input: 1.58, output: 5.51, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 262144,
+          maxTokens: 8192,
+        },
+        {
+          id: "private/kimi-k2-6",
+          name: "Kimi K2.6 (Private)",
+          reasoning: false,
+          input: ["text", "image"],
           cost: { input: 1.58, output: 5.51, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 262144,
           maxTokens: 8192,

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@
  *   1. Copy this plugin directory to your OpenClaw plugins folder
  *   2. Run `npm install` in the plugin directory
  *   3. Add your PPQ API key in OpenClaw settings
- *   4. Set model to any private model (e.g. private/kimi-k2-5)
+ *   4. Set model to any private model (e.g. private/kimi-k2-6)
  */
 
 import { startProxy, type ProxyHandle, type ProxyConfig } from "./lib/proxy.js";
@@ -97,9 +97,7 @@ export default function register(api: any) {
                     chat: `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
                   },
                   availableModels: [
-                    "private/kimi-k2-5",
                     "private/kimi-k2-6",
-                    "private/deepseek-r1-0528",
                     "private/gpt-oss-120b",
                     "private/llama3-3-70b",
                     "private/qwen3-vl-30b",
@@ -139,30 +137,12 @@ export default function register(api: any) {
       api: "openai-completions",
       models: [
         {
-          id: "private/kimi-k2-5",
-          name: "Kimi K2.5 (Private)",
-          reasoning: false,
-          input: ["text"],
-          cost: { input: 1.58, output: 5.51, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 262144,
-          maxTokens: 8192,
-        },
-        {
           id: "private/kimi-k2-6",
           name: "Kimi K2.6 (Private)",
           reasoning: false,
           input: ["text", "image"],
           cost: { input: 1.58, output: 5.51, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 262144,
-          maxTokens: 8192,
-        },
-        {
-          id: "private/deepseek-r1-0528",
-          name: "DeepSeek R1 (Private)",
-          reasoning: true,
-          input: ["text"],
-          cost: { input: 1.58, output: 5.51, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 131072,
           maxTokens: 8192,
         },
         {
@@ -227,7 +207,7 @@ export default function register(api: any) {
           if (typeof key === "symbol") throw new Error("Setup cancelled");
           return {
             profiles: [{ profileId: "default", credential: { apiKey: key } }],
-            defaultModel: "private/kimi-k2-5",
+            defaultModel: "private/kimi-k2-6",
           };
         },
       },

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -49,6 +49,7 @@ const HEALTH_TIMEOUT_MS = 15_000;
 /** Maps user-facing model IDs to enclave-internal model IDs */
 const PRIVATE_MODEL_MAP: Record<string, string> = {
   "private/kimi-k2-5": "kimi-k2-5",
+  "private/kimi-k2-6": "kimi-k2-6",
   "private/deepseek-r1-0528": "deepseek-r1-0528",
   "private/gpt-oss-120b": "gpt-oss-120b",
   "private/llama3-3-70b": "llama3-3-70b",
@@ -66,6 +67,12 @@ const MODEL_LIST_RESPONSE = {
   data: [
     {
       id: "private/kimi-k2-5",
+      object: "model",
+      created: 0,
+      owned_by: "ppq-private",
+    },
+    {
+      id: "private/kimi-k2-6",
       object: "model",
       created: 0,
       owned_by: "ppq-private",

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -48,9 +48,7 @@ const HEALTH_TIMEOUT_MS = 15_000;
 
 /** Maps user-facing model IDs to enclave-internal model IDs */
 const PRIVATE_MODEL_MAP: Record<string, string> = {
-  "private/kimi-k2-5": "kimi-k2-5",
   "private/kimi-k2-6": "kimi-k2-6",
-  "private/deepseek-r1-0528": "deepseek-r1-0528",
   "private/gpt-oss-120b": "gpt-oss-120b",
   "private/llama3-3-70b": "llama3-3-70b",
   "private/qwen3-vl-30b": "qwen3-vl-30b",
@@ -66,19 +64,7 @@ const MODEL_LIST_RESPONSE = {
   object: "list",
   data: [
     {
-      id: "private/kimi-k2-5",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-    {
       id: "private/kimi-k2-6",
-      object: "model",
-      created: 0,
-      owned_by: "ppq-private",
-    },
-    {
-      id: "private/deepseek-r1-0528",
       object: "model",
       created: 0,
       owned_by: "ppq-private",
@@ -184,7 +170,7 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
         const parsed = JSON.parse(body);
 
         // Resolve model
-        let modelId: string = parsed.model || "private/kimi-k2-5";
+        let modelId: string = parsed.model || "private/kimi-k2-6";
 
         // Ensure model is a valid private model
         if (!PRIVATE_MODEL_MAP[modelId]) {

--- a/skills/private-mode/SKILL.md
+++ b/skills/private-mode/SKILL.md
@@ -54,6 +54,7 @@ Here is the complete config to merge (replace `USER_API_KEY` with the actual key
         "api": "openai-completions",
         "models": [
           { "id": "private/kimi-k2-5", "name": "private/kimi-k2-5" },
+          { "id": "private/kimi-k2-6", "name": "private/kimi-k2-6" },
           { "id": "private/deepseek-r1-0528", "name": "private/deepseek-r1-0528" },
           { "id": "private/gpt-oss-120b", "name": "private/gpt-oss-120b" },
           { "id": "private/llama3-3-70b", "name": "private/llama3-3-70b" },
@@ -77,7 +78,7 @@ Here is the complete config to merge (replace `USER_API_KEY` with the actual key
 ```
 
 After merging, verify that `~/.openclaw/openclaw.json` contains BOTH:
-1. A `ppq-private` entry under `models.providers` with the 7 private models listed
+1. A `ppq-private` entry under `models.providers` with the 8 private models listed
 2. A `ppq-private-mode` entry under `plugins.entries` with the user's API key
 
 If either is missing, the private models will not work.
@@ -93,6 +94,7 @@ systemctl --user restart openclaw-gateway.service
 Tell the user PPQ Private Mode is configured. Available encrypted models:
 
 - `private/kimi-k2-5` -- Fast general tasks, 262K context
+- `private/kimi-k2-6` -- Latest Kimi, native multimodal, strong coding, 262K context
 - `private/deepseek-r1-0528` -- Reasoning and analysis
 - `private/gpt-oss-120b` -- Cost-efficient general use
 - `private/llama3-3-70b` -- Open-source tasks

--- a/skills/private-mode/SKILL.md
+++ b/skills/private-mode/SKILL.md
@@ -53,9 +53,7 @@ Here is the complete config to merge (replace `USER_API_KEY` with the actual key
         "apiKey": "unused",
         "api": "openai-completions",
         "models": [
-          { "id": "private/kimi-k2-5", "name": "private/kimi-k2-5" },
           { "id": "private/kimi-k2-6", "name": "private/kimi-k2-6" },
-          { "id": "private/deepseek-r1-0528", "name": "private/deepseek-r1-0528" },
           { "id": "private/gpt-oss-120b", "name": "private/gpt-oss-120b" },
           { "id": "private/llama3-3-70b", "name": "private/llama3-3-70b" },
           { "id": "private/qwen3-vl-30b", "name": "private/qwen3-vl-30b" },
@@ -78,7 +76,7 @@ Here is the complete config to merge (replace `USER_API_KEY` with the actual key
 ```
 
 After merging, verify that `~/.openclaw/openclaw.json` contains BOTH:
-1. A `ppq-private` entry under `models.providers` with the 8 private models listed
+1. A `ppq-private` entry under `models.providers` with the 6 private models listed
 2. A `ppq-private-mode` entry under `plugins.entries` with the user's API key
 
 If either is missing, the private models will not work.
@@ -93,16 +91,14 @@ systemctl --user restart openclaw-gateway.service
 
 Tell the user PPQ Private Mode is configured. Available encrypted models:
 
-- `private/kimi-k2-5` -- Fast general tasks, 262K context
 - `private/kimi-k2-6` -- Latest Kimi, native multimodal, strong coding, 262K context
-- `private/deepseek-r1-0528` -- Reasoning and analysis
 - `private/gpt-oss-120b` -- Cost-efficient general use
 - `private/llama3-3-70b` -- Open-source tasks
 - `private/qwen3-vl-30b` -- Vision plus text, 262K context
 - `private/glm-5-1` -- Agentic engineering with long-horizon tool use, 202K context
 - `private/gemma4-31b` -- Vision plus text with thinking mode, 262K context
 
-Switch with: `openclaw models set private/kimi-k2-5`
+Switch with: `openclaw models set private/kimi-k2-6`
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Two related commits that together migrate the proxy off Tinfoil's deprecated private models:

1. **Add `private/kimi-k2-6`** (PayPerQ/PPQdotAI#2126):
   - Adds it to the `supportedModels` allowlist and mock-models provider list in `index.ts`.
   - Adds the enclave routing entry (`"private/kimi-k2-6": "kimi-k2-6"`) and OpenAI-shape entry in `lib/proxy.ts`.
   - Adds the JSON model entry and description bullet in `skills/private-mode/SKILL.md`.
   - Marked multimodal (`input: ["text", "image"]`) and 262K context to match Tinfoil's upstream capability.

2. **Remove deprecated `private/kimi-k2-5` and `private/deepseek-r1-0528`** (PayPerQ/PPQdotAI#2282):
   - Tinfoil has dropped both models (verified — direct API calls return 404 "The model does not exist", and they're absent from `GET https://inference.tinfoil.sh/v1/models`).
   - Removes them from the allowlist, `PRIVATE_MODEL_MAP`, `MODEL_LIST_RESPONSE`, OpenClaw provider metadata, and `SKILL.md` openclaw.json template.
   - Updates the JSDoc, README example, and `bin/server.ts` example to use `private/kimi-k2-6`.
   - Switches the default model in both the proxy (`lib/proxy.ts` fallback) and the OpenClaw auth handler (`index.ts` `defaultModel`) from `private/kimi-k2-5` to `private/kimi-k2-6`.

Bundling them together is intentional: shipping the add separately would leave a window where the default model still points at K2.5, which has been removed upstream.

Closes PayPerQ/PPQdotAI#2126
Closes PayPerQ/PPQdotAI#2282

Paired chatbot PRs (remove same models from the main UI and backend):
- PayPerQ/PPQdotAI#2284
- PayPerQ/horse-power#529

## Test plan

- [ ] After publishing a new proxy version, `npx ppq-private-mode` starts cleanly with no `private/kimi-k2-5` references in logs.
- [ ] `curl http://127.0.0.1:8787/v1/models` returns 6 models (`kimi-k2-6`, `gpt-oss-120b`, `llama3-3-70b`, `qwen3-vl-30b`, `glm-5-1`, `gemma4-31b`) — no kimi-k2-5 or deepseek-r1-0528.
- [ ] A chat request omitting `model` defaults to `private/kimi-k2-6` and succeeds (previously would have hit a deprecated K2.5).
- [ ] OpenClaw installation flow assigns `private/kimi-k2-6` as the default model on setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)