### PR TITLE
Release 0.2.0 — republish current private-model catalog to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppq-private-mode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "End-to-end encrypted AI proxy for PPQ.AI private models. Works standalone or as an OpenClaw plugin.",
   "openclaw": {


### PR DESCRIPTION
## Summary
- Bump version `0.1.0 → 0.2.0` and republish `ppq-private-mode` to npm.

The published `ppq-private-mode@0.1.0` (npm, 2026-03-13) predated the model-catalog updates already merged to `main`, so the live tarball still shipped deprecated ids — `private/kimi-k2-5` and `private/deepseek-r1-0528` — causing **404s** for users (reported via https://x.com/bradmillscan/status/2066957938535571632).

The source was already correct (`kimi-k2-6`, `glm-5-1`, `gemma4-31b` added; K2.5/DeepSeek removed in `f5e7a82`/`fac8001`); it had simply never been republished. **0.2.0 is now live on npm** and its tarball matches the backend's 6 private models with zero stale ids.

Closes #2357

## Test plan
- [x] `npm view ppq-private-mode version` → `0.2.0`
- [x] Published 0.2.0 tarball `lib/proxy.ts` maps the 6 current private models; no `kimi-k2-5`/`deepseek` remain
- [ ] `npx ppq-private-proxy` → `/v1/models` lists `private/kimi-k2-6`, `private/glm-5-1`, `private/gemma4-31b`