### PR TITLE
Ship compiled JS so npx works (+ per-request Authorization, Node 20+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tgz
+pnpm-lock.yaml
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In some cases, openclaw's safety guardrails block installation via direct links.
 
 You can run the proxy directly without OpenClaw and point any OpenAI-compatible client at it.
 
-**Prerequisites:** Node.js 18+ and a PPQ.AI API key from [ppq.ai/api-docs](https://ppq.ai/api-docs).
+**Prerequisites:** Node.js 20+ and a PPQ.AI API key from [ppq.ai/api-docs](https://ppq.ai/api-docs).
 
 **Start the proxy:**
 
@@ -37,6 +37,15 @@ The proxy starts on port 8787 and prints a ready message once attestation succee
 ```bash
 curl http://127.0.0.1:8787/v1/chat/completions \
   -H "Content-Type: application/json" \
+  -d '{"model":"private/kimi-k2-6","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+The proxy bills against `PPQ_API_KEY` by default. To use a different key per request, pass it as a bearer token and the proxy will forward it instead:
+
+```bash
+curl http://127.0.0.1:8787/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-another-key" \
   -d '{"model":"private/kimi-k2-6","messages":[{"role":"user","content":"Hello"}]}'
 ```
 

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -202,11 +202,18 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
 
         // Forward via SecureClient (EHBP-encrypted)
         const endpoint = `${apiBase}/private/v1/chat/completions`;
+        // Prefer a per-request Authorization header (lets callers pass their own
+        // key per call); fall back to the key the proxy was started with.
+        const incomingAuth = req.headers["authorization"];
+        const upstreamAuth =
+          typeof incomingAuth === "string" && incomingAuth.trim()
+            ? incomingAuth
+            : `Bearer ${config.apiKey}`;
         const response = await encryptedFetch(endpoint, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${config.apiKey}`,
+            Authorization: upstreamAuth,
             "X-Private-Model": modelId,
             "x-query-source": "api",
           },

--- a/package.json
+++ b/package.json
@@ -1,25 +1,27 @@
 {
   "name": "ppq-private-mode",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "End-to-end encrypted AI proxy for PPQ.AI private models. Works standalone or as an OpenClaw plugin.",
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   },
   "bin": {
-    "ppq-private-proxy": "./bin/server.ts"
+    "ppq-private-proxy": "./dist/bin/server.js"
   },
   "scripts": {
-    "start": "npx tsx bin/server.ts"
+    "build": "tsc",
+    "start": "npx tsx bin/server.ts",
+    "prepare": "tsc",
+    "prepublishOnly": "tsc"
   },
   "files": [
-    "index.ts",
-    "lib",
-    "bin",
+    "dist",
     "skills",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "README.md"
   ],
   "dependencies": {
     "tinfoil": "^1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "outDir": "dist"
   },
-  "include": ["index.ts", "lib/**/*.ts"]
+  "include": ["index.ts", "lib/**/*.ts", "bin/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Fixes the standalone `npx ppq-private-mode` path, which **failed on every Node version** because the published `bin` was a TypeScript file run with `node` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` on 22, syntax error on 18).

- **Compile to `dist/`** via a `prepublishOnly`/`prepare` `tsc` build; point `bin` and `openclaw.extensions` at the JS output. `files` now ships `dist` instead of raw `.ts`.
- **Honor a per-request `Authorization` header** (falls back to the startup `PPQ_API_KEY`) — previously the header was silently ignored.
- **README**: `Node.js 18+` → `20+` (deps require ≥20), and document the per-request key option.
- Add `.gitignore` (`dist/`, `*.tgz`, `node_modules/`).

## Verification (Node 22)
- `npm run build` clean; shebang preserved in `dist/bin/server.js`.
- Packed the tarball, installed it into a clean project, ran `npx ppq-private-mode` → **boots in ~1s, no type-stripping error**, `/v1/models` lists all six models incl. `private/glm-5-2`.
- `dist/index.js` (OpenClaw entry) imports cleanly.

Closes #16