### PR TITLE
Only forward exact-shape PPQ keys upstream; fall back to PPQ_API_KEY (0.2.3)

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -202,13 +202,19 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
 
         // Forward via SecureClient (EHBP-encrypted)
         const endpoint = `${apiBase}/private/v1/chat/completions`;
-        // Prefer a per-request Authorization header (lets callers pass their own
-        // key per call); fall back to the key the proxy was started with.
+        // Allow callers to pass their own PPQ key per request, but ONLY forward it
+        // when it has the exact PPQ key shape ("sk-" + 22 [A-Za-z0-9]). Agent clients
+        // routinely send their own placeholder Authorization header to a local
+        // OpenAI-compatible endpoint — both obvious ones ("Bearer none", "ollama")
+        // and sk-prefixed ones ("Bearer sk-no-key-required"). Forwarding any of those
+        // upstream overrode PPQ_API_KEY and produced a plaintext 401, which the EHBP
+        // client surfaced as the misleading "missing ehbp-response-nonce header"
+        // ProtocolError. Anything that isn't a real PPQ key falls back to the key the
+        // proxy was started with.
         const incomingAuth = req.headers["authorization"];
-        const upstreamAuth =
-          typeof incomingAuth === "string" && incomingAuth.trim()
-            ? incomingAuth
-            : `Bearer ${config.apiKey}`;
+        const trimmedAuth = typeof incomingAuth === "string" ? incomingAuth.trim() : "";
+        const forwardable = /^Bearer\s+sk-[A-Za-z0-9]{22}$/.test(trimmedAuth);
+        const upstreamAuth = forwardable ? trimmedAuth : `Bearer ${config.apiKey}`;
         const response = await encryptedFetch(endpoint, {
           method: "POST",
           headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ppq/private-mode-proxy",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ppq/private-mode-proxy",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "dependencies": {
         "tinfoil": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppq-private-mode",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "End-to-end encrypted AI proxy for PPQ.AI private models. Works standalone or as an OpenClaw plugin.",
   "openclaw": {


### PR DESCRIPTION
## Summary
Fixes a regression introduced in **0.2.2** that broke private-mode for users whose agent sends its own `Authorization` header.

0.2.2 began forwarding the **client's** `Authorization` header to `api.ppq.ai`, falling back to `PPQ_API_KEY` only when no header was present. But OpenAI-compatible agent clients routinely send a placeholder bearer token to a local endpoint (`Bearer none`, `ollama`, even `sk-no-key-required`). The proxy forwarded that instead of the configured key, the backend rejected it with a **plaintext 401** *before* the enclave round-trip, and a plaintext reject carries no `ehbp-response-nonce` header — so the tinfoil client throws the misleading `ProtocolError: missing ehbp-response-nonce header`.

This matched a customer report exactly: two VMs, **same Containerfile, different agents** — only the VM with the header-injecting agent broke. `PPQ_API_KEY` was present and correct; it was simply being overridden.

## Change
Forward the incoming header only when it matches the **exact PPQ key shape** (`sk-` + 22 `[A-Za-z0-9]`, per `generateVirtualKey`); otherwise use `PPQ_API_KEY`.

| Incoming `Authorization` | Before (0.2.2) | After (0.2.3) |
|---|---|---|
| (none) | `PPQ_API_KEY` ✅ | `PPQ_API_KEY` ✅ |
| `Bearer none` / `ollama` | forwarded → 401 ❌ | `PPQ_API_KEY` ✅ |
| `Bearer sk-no-key-required` | forwarded → 401 ❌ | `PPQ_API_KEY` ✅ |
| real `sk-…` key (per-request) | forwarded ✅ | forwarded ✅ |

No currently-working setup regresses; only the broken case changes. Bumps to **0.2.3** (`dist/` is gitignored and rebuilt on publish via `prepublishOnly`).

## Test plan
- [x] `tsc` build clean
- [x] Logic table above verified against the compiled regex
- [ ] Publish 0.2.3 to npm; confirm a placeholder-header agent now authenticates via `PPQ_API_KEY`