### PR TITLE
Forward validated X-Tool-Id header for creator payouts (0.3.2)

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -158,6 +158,18 @@ function computeUpstreamAuth(req: http.IncomingMessage, config: ProxyConfig): st
   return forwardable ? trimmedAuth : `Bearer ${config.apiKey}`;
 }
 
+/**
+ * Extract a creator-payout tool id (e.g. "stt:ppq-voice") from the incoming
+ * `X-Tool-Id` header so PPQ can pay the registered tool creator for the
+ * request. The request body is encrypted before it reaches PPQ, so this is
+ * forwarded as a cleartext metadata header alongside X-Private-Model. Only a
+ * single conservatively-shaped value is forwarded; anything else is dropped.
+ */
+function computeToolId(req: http.IncomingMessage): string | null {
+  const incoming = req.headers["x-tool-id"];
+  return typeof incoming === "string" && /^[\w:.-]{1,64}$/.test(incoming) ? incoming : null;
+}
+
 // ─── Proxy server ────────────────────────────────────────────────────────────
 
 export async function startProxy(config: ProxyConfig, logger: Logger): Promise<ProxyHandle> {
@@ -195,16 +207,21 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
   function forwardEncrypted(
     openaiBody: Record<string, unknown>,
     modelId: string,
-    upstreamAuth: string
+    upstreamAuth: string,
+    toolId: string | null = null
   ): Promise<Response> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Authorization: upstreamAuth,
+      "X-Private-Model": modelId,
+      "x-query-source": "api",
+    };
+    if (toolId) {
+      headers["X-Tool-Id"] = toolId;
+    }
     return encryptedFetch(`${apiBase}/private/v1/chat/completions`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: upstreamAuth,
-        "X-Private-Model": modelId,
-        "x-query-source": "api",
-      },
+      headers,
       body: JSON.stringify(openaiBody),
     });
   }
@@ -213,7 +230,10 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
     // CORS headers
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    res.setHeader(
+      "Access-Control-Allow-Headers",
+      "Content-Type, Authorization, X-Tool-Id"
+    );
 
     if (req.method === "OPTIONS") {
       res.writeHead(204);
@@ -269,7 +289,8 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
         const response = await forwardEncrypted(
           parsed,
           resolved.modelId,
-          computeUpstreamAuth(req, config)
+          computeUpstreamAuth(req, config),
+          computeToolId(req)
         );
 
         // Forward status and headers
@@ -327,7 +348,8 @@ export async function startProxy(config: ProxyConfig, logger: Logger): Promise<P
         const response = await forwardEncrypted(
           openaiBody,
           resolved.modelId,
-          computeUpstreamAuth(req, config)
+          computeUpstreamAuth(req, config),
+          computeToolId(req)
         );
 
         const messageId = newMessageId();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ppq/private-mode-proxy",
-  "version": "0.2.3",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ppq/private-mode-proxy",
-      "version": "0.2.3",
+      "version": "0.3.2",
       "dependencies": {
         "tinfoil": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppq-private-mode",
-  "version": "0.2.3",
+  "version": "0.3.2",
   "type": "module",
   "description": "End-to-end encrypted AI proxy for PPQ.AI private models. Works standalone or as an OpenClaw plugin.",
   "openclaw": {
@@ -29,6 +29,11 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.0"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "tsx": "^4.0.0",


### PR DESCRIPTION
## Summary
- Validate an incoming `X-Tool-Id` header (`/^[\w:.-]{1,64}$/`, single string only) and forward it to horse-power on both the OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) endpoints, alongside `X-Private-Model`. Anything malformed is dropped.
- Add `X-Tool-Id` to the local server's CORS `Access-Control-Allow-Headers`.
- Version 0.3.2. Also folds in the `peerDependenciesMeta` (optional openclaw) change from the 0.3.1 npm release, which was published from `feat/anthropic-messages-endpoint` but never landed on main — this realigns main with what's on npm.

This lets PPQ Whisper's private-mode LLM cleanup carry its creator-payout id (`stt:ppq-voice`) to horse-power, which cannot read the encrypted body. Companion PRs: PayPerQ/horse-power#653 (reads the header, fires the payout) and ppq-voice (sends it).

Refs PayPerQ/horse-power#652

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Publish 0.3.2 to npm after merge, then verify a proxied request with `X-Tool-Id` produces a CHAT payout row via horse-power staging