### PR TITLE
Sync private-model display costs with the Tinfoil rate card (0.4.2)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -134,13 +134,18 @@ export default function register(api: any) {
     models: {
       baseUrl: `http://127.0.0.1:${pluginConfig.port || 8787}`,
       api: "openai-completions",
+      // `cost` is what OpenClaw shows the user per 1M tokens. It must track
+      // PPQ's API-tier price: the Tinfoil rate card × the 1.055 API margin.
+      // Rate card: https://api.tinfoil.sh/api/config/models (last synced
+      // 2026-08-12, when Tinfoil corrected Kimi K3 from $2/$6 to $4/$20).
       models: [
         {
           id: "private/kimi-k3",
           name: "Kimi K3 (Private)",
           reasoning: true,
           input: ["text", "image"],
-          cost: { input: 2.11, output: 6.33, cacheRead: 0, cacheWrite: 0 },
+          // $4.00 / $20.00 × 1.055
+          cost: { input: 4.22, output: 21.1, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 256000,
           maxTokens: 8192,
         },
@@ -149,7 +154,8 @@ export default function register(api: any) {
           name: "GPT-OSS 120B (Private)",
           reasoning: false,
           input: ["text"],
-          cost: { input: 0.79, output: 1.31, cacheRead: 0, cacheWrite: 0 },
+          // $0.15 / $0.60 × 1.055
+          cost: { input: 0.16, output: 0.63, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 131072,
           maxTokens: 8192,
         },
@@ -158,7 +164,8 @@ export default function register(api: any) {
           name: "Llama 3.3 70B (Private)",
           reasoning: false,
           input: ["text"],
-          cost: { input: 1.84, output: 2.89, cacheRead: 0, cacheWrite: 0 },
+          // $1.75 / $2.75 × 1.055
+          cost: { input: 1.85, output: 2.9, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 131072,
           maxTokens: 8192,
         },
@@ -167,7 +174,10 @@ export default function register(api: any) {
           name: "GLM-5.2 (Private)",
           reasoning: true,
           input: ["text"],
-          cost: { input: 1.58, output: 5.51, cacheRead: 0, cacheWrite: 0 },
+          // $1.50 / $5.25 × 1.055; cached input $0.375 × 1.055 — the only
+          // private model whose rate card prices a cache-read tier, and
+          // horse-power bills those attested cached tokens at it (hp #723).
+          cost: { input: 1.58, output: 5.54, cacheRead: 0.4, cacheWrite: 0 },
           contextWindow: 384000,
           maxTokens: 8192,
         },
@@ -176,7 +186,8 @@ export default function register(api: any) {
           name: "Gemma 4 31B (Private)",
           reasoning: true,
           input: ["text", "image"],
-          cost: { input: 0.47, output: 1.05, cacheRead: 0, cacheWrite: 0 },
+          // $0.40 / $1.00 × 1.055
+          cost: { input: 0.42, output: 1.06, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 262144,
           maxTokens: 8192,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ppq/private-mode-proxy",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ppq/private-mode-proxy",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "tinfoil": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppq-private-mode",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "End-to-end encrypted AI proxy for PPQ.AI private models. Works standalone or as an OpenClaw plugin.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Companion to PayPerQ/horse-power#746. Tinfoil corrected Kimi K3 from $2/$6 to $4/$20 per 1M on 2026-08-12 (their misconfiguration, corrected ~16:00 UTC), so the OpenClaw cost estimate for `private/kimi-k3` moves to **$4.22 / $21.10** — rate card × the 1.055 API margin PPQ actually bills at.

These `cost` fields are **display-only** — horse-power does the real billing — but a user watching a $6.33/M output estimate while being charged $21.10/M is a support ticket waiting to happen.

## Drive-by: three siblings were also stale

While re-checking the table against the live rate card (`GET https://api.tinfoil.sh/api/config/models`), three other entries turned out not to match. Called out separately so they're easy to drop if considered out of scope:

| model | before | after | why |
|---|---|---|---|
| `private/kimi-k3` | 2.11 / 6.33 | **4.22 / 21.10** | the rate-card correction this PR is for |
| `private/gpt-oss-120b` | 0.79 / 1.31 | **0.16 / 0.63** | still carrying the pre-hp#583 base of $0.75/$1.25 — the exact stale numbers from the 2026-06-24 incident, fixed backend-side but never here |
| `private/gemma4-31b` | 0.47 / 1.05 | **0.42 / 1.06** | input was on the old $0.45 base |
| `private/glm-5-2` | 1.58 / 5.51, `cacheRead: 0` | **1.58 / 5.54, `cacheRead: 0.40`** | output was a rounding slip; free cache reads understate spend now that horse-power bills attested cached tokens at the $0.375 cached rate (hp #723) |
| `private/llama3-3-70b` | 1.84 / 2.89 | **1.85 / 2.90** | rounding |

Also added a comment recording what these numbers are (rate card × 1.055 API margin) and when they were last synced, so the next person doesn't have to re-derive it.

## Changes

- `index.ts` — provider `cost` fields for all five private models
- `package.json` / `package-lock.json` — 0.4.1 → 0.4.2

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Publish npm `ppq-private-mode@0.4.2` after merge
- [ ] Spot-check OpenClaw shows the new per-1M estimates for `private/kimi-k3`