### PR TITLE
Add DeepSeek V4 Flash to private model catalog

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -102,6 +102,7 @@ export default function register(api: any) {
                     "private/llama3-3-70b",
                     "private/glm-5-2",
                     "private/gemma4-31b",
+                    "private/deepseek-v4-flash",
                   ],
                 }),
               },
@@ -189,6 +190,17 @@ export default function register(api: any) {
           // $0.40 / $1.00 × 1.055
           cost: { input: 0.42, output: 1.06, cacheRead: 0, cacheWrite: 0 },
           contextWindow: 262144,
+          maxTokens: 8192,
+        },
+        {
+          id: "private/deepseek-v4-flash",
+          name: "DeepSeek V4 Flash (Private)",
+          reasoning: true,
+          input: ["text"],
+          // $0.30 / $0.70 × 1.055; cached input $0.06 × 1.055 — horse-power
+          // bills the enclave's attested cached tokens at that tier (hp #723).
+          cost: { input: 0.32, output: 0.74, cacheRead: 0.06, cacheWrite: 0 },
+          contextWindow: 1048576,
           maxTokens: 8192,
         },
       ],

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -86,6 +86,7 @@ const PRIVATE_MODEL_MAP: Record<string, string> = {
   "private/llama3-3-70b": "llama3-3-70b",
   "private/glm-5-2": "glm-5-2",
   "private/gemma4-31b": "gemma4-31b",
+  "private/deepseek-v4-flash": "deepseek-v4-flash",
 };
 
 /** All available private model IDs (user-facing) */
@@ -121,6 +122,12 @@ const MODEL_LIST_RESPONSE = {
     },
     {
       id: "private/gemma4-31b",
+      object: "model",
+      created: 0,
+      owned_by: "ppq-private",
+    },
+    {
+      id: "private/deepseek-v4-flash",
       object: "model",
       created: 0,
       owned_by: "ppq-private",

--- a/skills/private-mode/SKILL.md
+++ b/skills/private-mode/SKILL.md
@@ -57,7 +57,8 @@ Here is the complete config to merge (replace `USER_API_KEY` with the actual key
           { "id": "private/gpt-oss-120b", "name": "private/gpt-oss-120b" },
           { "id": "private/llama3-3-70b", "name": "private/llama3-3-70b" },
           { "id": "private/glm-5-2", "name": "private/glm-5-2" },
-          { "id": "private/gemma4-31b", "name": "private/gemma4-31b" }
+          { "id": "private/gemma4-31b", "name": "private/gemma4-31b" },
+          { "id": "private/deepseek-v4-flash", "name": "private/deepseek-v4-flash" }
         ]
       }
     }
@@ -95,6 +96,7 @@ Tell the user PPQ Private Mode is configured. Available encrypted models:
 - `private/llama3-3-70b` -- Open-source tasks
 - `private/glm-5-2` -- Agentic engineering with long-horizon tool use, 384K context
 - `private/gemma4-31b` -- Vision plus text with thinking mode, 262K context
+- `private/deepseek-v4-flash` -- Fast, cost-efficient reasoning and coding, 1M context
 
 Switch with: `openclaw models set private/kimi-k3`
 


### PR DESCRIPTION
## Summary
Adds `private/deepseek-v4-flash` to the proxy's hardcoded catalog.

Spec pulled live from `https://inference.tinfoil.sh/v1/models`:
- 1,048,576 context window, reasoning, tool calling, no vision
- $0.30/1M input, $0.70/1M output, $0.06/1M cached input

Changes:
- `lib/proxy.ts` — `PRIVATE_MODEL_MAP` + `MODEL_LIST_RESPONSE.data`
- `index.ts` — status-tool `availableModels` + OpenClaw provider entry (costs are upstream × 1.055 API margin: `input: 0.32`, `output: 0.74`, `cacheRead: 0.06`)
- `skills/private-mode/SKILL.md` — both model lists

Net-new model — nothing removed.

Ships with PayPerQ/PPQdotAI#2691 and PayPerQ/horse-power#798.

Closes #25

## Test plan
- [x] `pnpm build` passes
- [ ] `GET /v1/models` on the running proxy lists `private/deepseek-v4-flash`
- [ ] A request routed through the proxy reaches the enclave
- [ ] **Republish `ppq-private-mode` to npm after merge** — `npx` users stay on the stale catalog until then

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the DeepSeek V4 Flash model in private mode.
  * Enabled reasoning and text input capabilities.
  * Supports up to 1 million tokens of context and 8,192 output tokens.
  * Added pricing and cache-read pricing details.
  * Included the model in available private model listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->